### PR TITLE
avm2: Call 'AS3::concat' in ColorMatrixFilter

### DIFF
--- a/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
+++ b/core/src/avm2/globals/flash/filters/ColorMatrixFilter.as
@@ -16,17 +16,20 @@
 
 		// From the Flash docs, we need to make a copy of the `Array`,
 		// as modifying the `filter.matrix` directly should have no effect.
+		// We call the method in the AS3 namespace, as some SWFS define a
+		// extend `Array` and declare a *public* 'concat' method with a
+		// different signature.
 
 		public function get matrix(): Array {
-			return this._matrix.concat();
+			return this._matrix.AS3::concat();
 		}
 
 		public function set matrix(matrix:Array):void {
-			this._matrix = matrix.concat();
+			this._matrix = matrix.AS3::concat();
 		}
 
 		override public function clone(): BitmapFilter {
-			return new ColorMatrixFilter(this.matrix.concat());
+			return new ColorMatrixFilter(this.matrix.AS3::concat());
 		}
 	}
 }


### PR DESCRIPTION
This ensures that we call the normal Array concat method (or a method that overrides it). Some SWFs may define a *public* concat method in an Array subclass, with a different signature.

Fixes #10552